### PR TITLE
fix: properties mixup

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -4,6 +4,14 @@ function hasProperty(block: BlockEntity, propertyKey: string): boolean {
   return block.properties?.[propertyKey] !== undefined;
 }
 
+function propertyKeyChange(properties:any){
+  if(!properties) return properties;
+  let res = {};
+  const repalceFunc = (text:string)=>text.replace(/([A-Z])/g, "-$1").toLowerCase();
+  Object.keys(properties).forEach(k=> res[repalceFunc(k)] = properties[k]);
+  return res;
+}
+
 export function toBatchBlocks(blocks: BlockEntity[]) {
   return blocks.map((c) => ({
     content: c.content,
@@ -11,7 +19,7 @@ export function toBatchBlocks(blocks: BlockEntity[]) {
     children: c.children?.length
       ? toBatchBlocks(c.children as BlockEntity[])
       : undefined,
-    properties: c.properties,
+    properties: propertyKeyChange(c.properties),
   }));
 }
 


### PR DESCRIPTION
fix #6 

logseq parse property keys into camel style, and insert into lowercase.

so properties 
```
lc-tags:: Array
```
will be parsed to object
```
{lcTags: Array}
```
and then insert as a block:
```
lctags:: Array
```
Duplicate with content, the result is 
```
lc-tags::Array
lctags:: Array
```

I am poor in JavaScript and this pull request only solve my problem with '-' property style.
I hope it helps.